### PR TITLE
Errant "since" in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,10 @@ asynchronous operations, perform those first before calling `render`.
 
 ## A note about whitespace
 
-CoffeeScript is whitespace-sensitive, but your templates aren't. Eco code tags that begin an indented CoffeeScript block are suffixed with a colon. To indicate the end of an indented block, use the special tag `<% end %>`. For example:
+CoffeeScript is whitespace-sensitive, but your templates aren't.
+Eco code tags that begin an indented CoffeeScript block are
+suffixed with a colon. To indicate the end of an indented block,
+use the special tag `<% end %>`. For example:
 
     <% if @project.isOnHold(): %>
       On Hold

--- a/README.md
+++ b/README.md
@@ -62,10 +62,10 @@ asynchronous operations, perform those first before calling `render`.
 
 ## A note about whitespace
 
-CoffeeScript is whitespace-sensitive, but your templates aren't.
-Eco code tags that begin an indented CoffeeScript block are
-suffixed with a colon. To indicate the end of an indented block,
-use the special tag `<% end %>`. For example:
+CoffeeScript is whitespace-sensitive, but your templates aren't. Eco
+code tags that begin an indented CoffeeScript block are suffixed
+with a colon. To indicate the end of an indented block, use the
+special tag `<% end %>`. For example:
 
     <% if @project.isOnHold(): %>
       On Hold

--- a/README.md
+++ b/README.md
@@ -62,10 +62,7 @@ asynchronous operations, perform those first before calling `render`.
 
 ## A note about whitespace
 
-Since CoffeeScript is whitespace-sensitive, but your templates aren't,
-Eco code tags that begin an indented CoffeeScript block are suffixed
-with a colon. To indicate the end of an indented block, use the
-special tag `<% end %>`. For example:
+CoffeeScript is whitespace-sensitive, but your templates aren't. Eco code tags that begin an indented CoffeeScript block are suffixed with a colon. To indicate the end of an indented block, use the special tag `<% end %>`. For example:
 
     <% if @project.isOnHold(): %>
       On Hold


### PR DESCRIPTION
Just a minor doc fix. Noticed an odd sentence construction in the whitespace section. Code attached.
