### PR TITLE
Render %%> as %>

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -1,6 +1,6 @@
 (function() {
-  var compile, compileToFile, each, eachFile, eco, exec, fs, indent, mkdir, parseOptions, path, preprocessArgs, printUsage, printVersion, read, stripExtension, sys;
-  var __slice = Array.prototype.slice;
+  var compile, compileToFile, each, eachFile, eco, exec, fs, indent, mkdir, parseOptions, path, preprocessArgs, printUsage, printVersion, read, stripExtension, sys,
+    __slice = Array.prototype.slice;
 
   fs = require("fs");
 

--- a/lib/scanner.js
+++ b/lib/scanner.js
@@ -8,7 +8,7 @@
   module.exports = Scanner = (function() {
 
     Scanner.modePatterns = {
-      data: /(.*?)(<%%|<%\s*(\#)|<%(([=-])?)|\n|$)/,
+      data: /(.*?)(<%%|%%>|<%\s*(\#)|<%(([=-])?)|\n|$)/,
       code: /(.*?)((((:|(->|=>))\s*))?%>|\n|$)/,
       comment: /(.*?)(%>|\n|$)/
     };
@@ -72,6 +72,9 @@
     Scanner.prototype.scanData = function(callback) {
       if (this.tail === "<%%") {
         this.buffer += "<%";
+        return this.scan(callback);
+      } else if (this.tail === "%%>") {
+        this.buffer += "%>";
         return this.scan(callback);
       } else if (this.tail === "\n") {
         this.buffer += this.tail;

--- a/src/scanner.coffee
+++ b/src/scanner.coffee
@@ -3,7 +3,7 @@
 
 module.exports = class Scanner
   @modePatterns:
-    data:    /(.*?)(<%%|<%\s*(\#)|<%(([=-])?)|\n|$)/
+    data:    /(.*?)(<%%|%%>|<%\s*(\#)|<%(([=-])?)|\n|$)/
     code:    /(.*?)((((:|(->|=>))\s*))?%>|\n|$)/
     comment: /(.*?)(%>|\n|$)/
 
@@ -57,6 +57,10 @@ module.exports = class Scanner
   scanData: (callback) ->
     if @tail is "<%%"
       @buffer += "<%"
+      @scan callback
+
+    else if @tail is "%%>"
+      @buffer += "%>"
       @scan callback
 
     else if @tail is "\n"

--- a/test/test_eco.coffee
+++ b/test/test_eco.coffee
@@ -124,6 +124,10 @@ module.exports =
     test.same "<%", eco.render "<%%"
     test.done()
 
+  "rendering an escaped %>": (test) ->
+    test.same "%>", eco.render "%%>"
+    test.done()
+
   "requiring eco templates as modules": (test) ->
     hello = require __dirname + "/fixtures/hello.eco"
     test.ok typeof hello is "function"

--- a/test/test_scanner.coffee
+++ b/test/test_scanner.coffee
@@ -76,6 +76,13 @@ module.exports =
     test.same ["recordCode", "'<%%'"], tokens.shift()
     test.done()
 
+  "%%> prints an escaped %> in data mode": (test) ->
+    tokens = scan "a %%> b <%= '%%'+'>' %>"
+    test.same ["printString", "a %> b "], tokens.shift()
+    test.same ["beginCode", print: true, safe: false], tokens.shift()
+    test.same ["recordCode", "'%%'+'>'"], tokens.shift()
+    test.done()
+
   "unexpected newline in code block": (test) ->
     tokens = scan "foo\nhello <% do 'thing'\n %>"
     test.same ["printString", "foo\nhello "], tokens.shift()


### PR DESCRIPTION
The document says `%%>` will result in `%>`, but actually it doesn't happen.
This patch fixes that behavior.
