### PR TITLE
Update README to change reserved word 'yield'

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ value.
 
     eco.render template,
       project: { id: 1, name: "Mobile app" }
-      formFor: (project, yield) ->
+      formFor: (project, yield_to) ->
         form =
           textField: (attribute) =>
             name  = @escape attribute
@@ -197,7 +197,7 @@ value.
             @safe "<input type='text' name='#{name}' value='#{value}'>"
 
         url  = "/projects/#{@project.id}"
-        body = yield form
+        body = yield_to form
         @safe "<form action='#{url}' method='post'>#{body}</form>"
 
 Note: In general, you should use CoffeeScript's fat arrow (`=>`) to


### PR DESCRIPTION
As Coffeescript is now enforcing strict mode by default, the formFor example using 'yield' throws a syntax error.
