### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,7 @@
 , "description": "Embedded CoffeeScript templates"
 , "author": "Sam Stephenson"
 , "version": "1.1.0-rc-3"
-, "licenses": [
-  { "type": "MIT"
-  , "url": "https://github.com/sstephenson/eco/raw/master/LICENSE"
-  }]
+, "license": "MIT"
 , "main": "./lib/index.js"
 , "bin": "./bin/eco"
 , "repository":


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/
